### PR TITLE
feat: Add project structure and PostgreSQL configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/example/julestest/config/ExampleConfig.java
+++ b/src/main/java/com/example/julestest/config/ExampleConfig.java
@@ -1,0 +1,8 @@
+package com.example.julestest.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ExampleConfig {
+    // Placeholder for configuration beans
+}

--- a/src/main/java/com/example/julestest/controller/ExampleController.java
+++ b/src/main/java/com/example/julestest/controller/ExampleController.java
@@ -1,0 +1,8 @@
+package com.example.julestest.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ExampleController {
+    // Placeholder for controller endpoints
+}

--- a/src/main/java/com/example/julestest/domain/ExampleDomain.java
+++ b/src/main/java/com/example/julestest/domain/ExampleDomain.java
@@ -1,0 +1,5 @@
+package com.example.julestest.domain;
+
+public class ExampleDomain {
+    // Placeholder for domain objects
+}

--- a/src/main/java/com/example/julestest/repository/ExampleRepository.java
+++ b/src/main/java/com/example/julestest/repository/ExampleRepository.java
@@ -1,0 +1,8 @@
+package com.example.julestest.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExampleRepository { // Typically extends JpaRepository<Entity, ID>
+    // Placeholder for repository methods
+}

--- a/src/main/java/com/example/julestest/service/ExampleService.java
+++ b/src/main/java/com/example/julestest/service/ExampleService.java
@@ -1,0 +1,8 @@
+package com.example.julestest.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExampleService {
+    // Placeholder for service logic
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-spring.application.name=jules-test
+spring.datasource.url=jdbc:postgresql://localhost:5432/jules_db
+spring.datasource.username=jules_user
+spring.datasource.password=jules_password
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
- Created standard package structure:
  - com.example.julestest.domain
  - com.example.julestest.service
  - com.example.julestest.controller
  - com.example.julestest.repository
  - com.example.julestest.config
- Added placeholder classes in each new package.
- Added `postgresql` JDBC driver dependency to pom.xml.
- Configured PostgreSQL connection details in `application.properties` using placeholder credentials for database name, username, and password. Includes Hibernate dialect and ddl-auto settings.