### PR TITLE
feat: Implement PDF upload, hash generation, and metadata storage

### DIFF
--- a/src/main/java/com/example/julestest/controller/ExampleController.java
+++ b/src/main/java/com/example/julestest/controller/ExampleController.java
@@ -1,8 +1,0 @@
-package com.example.julestest.controller;
-
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class ExampleController {
-    // Placeholder for controller endpoints
-}

--- a/src/main/java/com/example/julestest/controller/PdfDocumentController.java
+++ b/src/main/java/com/example/julestest/controller/PdfDocumentController.java
@@ -1,0 +1,40 @@
+package com.example.julestest.controller;
+
+import com.example.julestest.domain.PdfDocument;
+import com.example.julestest.service.PdfDocumentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/pdf")
+@RequiredArgsConstructor
+public class PdfDocumentController {
+
+    private final PdfDocumentService pdfDocumentService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> uploadPdfFile(@RequestParam("file") MultipartFile file) {
+        if (file.isEmpty()) {
+            return ResponseEntity.badRequest().body("File cannot be empty");
+        }
+        // Simple validation for PDF content type (can be more robust)
+        if (file.getContentType() == null || !file.getContentType().equals("application/pdf")) {
+            return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Only PDF files are allowed");
+        }
+
+        try {
+            PdfDocument savedDocument = pdfDocumentService.storePdfFile(file);
+            return ResponseEntity.status(HttpStatus.CREATED).body(savedDocument);
+        } catch (Exception e) {
+            // Log the exception e.g., e.printStackTrace(); or use a logger
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                 .body("Could not upload the file: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/julestest/domain/PdfDocument.java
+++ b/src/main/java/com/example/julestest/domain/PdfDocument.java
@@ -1,0 +1,29 @@
+package com.example.julestest.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "pdf_documents")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PdfDocument {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fileName;
+    private String hashCode;
+    private String hashAlgorithm;
+    private LocalDateTime uploadTimestamp; // Changed from lastModifiedTimestamp to reflect upload time
+}

--- a/src/main/java/com/example/julestest/repository/ExampleRepository.java
+++ b/src/main/java/com/example/julestest/repository/ExampleRepository.java
@@ -1,8 +1,0 @@
-package com.example.julestest.repository;
-
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ExampleRepository { // Typically extends JpaRepository<Entity, ID>
-    // Placeholder for repository methods
-}

--- a/src/main/java/com/example/julestest/repository/PdfDocumentRepository.java
+++ b/src/main/java/com/example/julestest/repository/PdfDocumentRepository.java
@@ -1,0 +1,11 @@
+package com.example.julestest.repository;
+
+import com.example.julestest.domain.PdfDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PdfDocumentRepository extends JpaRepository<PdfDocument, Long> {
+    // Basic CRUD methods are inherited from JpaRepository
+    // Custom query methods can be added here if needed later
+}

--- a/src/main/java/com/example/julestest/service/ExampleService.java
+++ b/src/main/java/com/example/julestest/service/ExampleService.java
@@ -1,8 +1,0 @@
-package com.example.julestest.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class ExampleService {
-    // Placeholder for service logic
-}

--- a/src/main/java/com/example/julestest/service/PdfDocumentService.java
+++ b/src/main/java/com/example/julestest/service/PdfDocumentService.java
@@ -1,0 +1,46 @@
+package com.example.julestest.service;
+
+import com.example.julestest.domain.PdfDocument;
+import com.example.julestest.repository.PdfDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat; // Preferred for Java 17+
+
+@Service
+@RequiredArgsConstructor
+public class PdfDocumentService {
+
+    private final PdfDocumentRepository pdfDocumentRepository;
+    private static final String HASH_ALGORITHM = "SHA-256";
+
+    public PdfDocument storePdfFile(MultipartFile file) throws IOException, NoSuchAlgorithmException {
+        String fileName = file.getOriginalFilename();
+        String hashCode;
+
+        try (InputStream inputStream = file.getInputStream()) {
+            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
+            }
+            byte[] hashedBytes = digest.digest();
+            hashCode = HexFormat.of().formatHex(hashedBytes); // Using Java 17's HexFormat
+        }
+
+        PdfDocument pdfDocument = new PdfDocument();
+        pdfDocument.setFileName(fileName);
+        pdfDocument.setHashCode(hashCode);
+        pdfDocument.setHashAlgorithm(HASH_ALGORITHM);
+        pdfDocument.setUploadTimestamp(LocalDateTime.now());
+
+        return pdfDocumentRepository.save(pdfDocument);
+    }
+}

--- a/src/test/java/com/example/julestest/service/PdfDocumentServiceTest.java
+++ b/src/test/java/com/example/julestest/service/PdfDocumentServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.julestest.service;
+
+import com.example.julestest.domain.PdfDocument;
+import com.example.julestest.repository.PdfDocumentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile; // Spring's mock for MultipartFile
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PdfDocumentServiceTest {
+
+    @Mock
+    private PdfDocumentRepository pdfDocumentRepository;
+
+    @InjectMocks
+    private PdfDocumentService pdfDocumentService;
+
+    private MockMultipartFile mockFile;
+    private final String testFileContent = "This is a test PDF content.";
+    private final String expectedHashAlgorithm = "SHA-256";
+    private String expectedHashCode;
+
+    @BeforeEach
+    void setUp() throws NoSuchAlgorithmException {
+        mockFile = new MockMultipartFile(
+                "file", // parameter name
+                "test.pdf", // original filename
+                "application/pdf", // content type
+                testFileContent.getBytes(StandardCharsets.UTF_8) // content
+        );
+
+        // Calculate expected hash
+        MessageDigest digest = MessageDigest.getInstance(expectedHashAlgorithm);
+        byte[] hashedBytes = digest.digest(testFileContent.getBytes(StandardCharsets.UTF_8));
+        expectedHashCode = HexFormat.of().formatHex(hashedBytes);
+    }
+
+    @Test
+    void storePdfFile_shouldProcessFileAndSaveDocument() throws IOException, NoSuchAlgorithmException {
+        // Arrange
+        PdfDocument savedDocument = new PdfDocument();
+        savedDocument.setId(1L);
+        savedDocument.setFileName(mockFile.getOriginalFilename());
+        savedDocument.setHashCode(expectedHashCode);
+        savedDocument.setHashAlgorithm(expectedHashAlgorithm);
+        savedDocument.setUploadTimestamp(LocalDateTime.now()); // Timestamp will be close
+
+        when(pdfDocumentRepository.save(any(PdfDocument.class))).thenReturn(savedDocument);
+
+        // Act
+        PdfDocument result = pdfDocumentService.storePdfFile(mockFile);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(mockFile.getOriginalFilename(), result.getFileName());
+        assertEquals(expectedHashCode, result.getHashCode());
+        assertEquals(expectedHashAlgorithm, result.getHashAlgorithm());
+        assertNotNull(result.getUploadTimestamp());
+
+        ArgumentCaptor<PdfDocument> documentCaptor = ArgumentCaptor.forClass(PdfDocument.class);
+        verify(pdfDocumentRepository, times(1)).save(documentCaptor.capture());
+
+        PdfDocument capturedDocument = documentCaptor.getValue();
+        assertEquals(mockFile.getOriginalFilename(), capturedDocument.getFileName());
+        assertEquals(expectedHashCode, capturedDocument.getHashCode());
+        assertEquals(expectedHashAlgorithm, capturedDocument.getHashAlgorithm());
+        assertNotNull(capturedDocument.getUploadTimestamp()); // Check timestamp exists
+    }
+
+    @Test
+    void storePdfFile_withEmptyFile_shouldThrowIOException() {
+        // This test is more for the controller, but shows how service might react to empty stream
+        MockMultipartFile emptyFile = new MockMultipartFile("file", "empty.pdf", "application/pdf", new byte[0]);
+
+        // Recalculate expected hash for empty content
+        String emptyContentExpectedHashCode;
+        try {
+            MessageDigest digest = MessageDigest.getInstance(expectedHashAlgorithm);
+            byte[] hashedBytes = digest.digest(new byte[0]);
+            emptyContentExpectedHashCode = HexFormat.of().formatHex(hashedBytes);
+        } catch (NoSuchAlgorithmException e) {
+            fail("NoSuchAlgorithmException for SHA-256");
+            return;
+        }
+
+        assertDoesNotThrow(() -> {
+            PdfDocument result = pdfDocumentService.storePdfFile(emptyFile);
+            assertEquals(emptyContentExpectedHashCode, result.getHashCode(), "Hash code for empty content should match.");
+        }, "Processing an empty file should not throw an exception at service level if stream is valid, hash will be of empty content.");
+    }
+}


### PR DESCRIPTION
This feature allows you to upload PDF files via a REST API endpoint. For each uploaded PDF, the system:
1. Generates a SHA-256 hash of the file content.
2. Stores metadata including the original file name, the generated hash, the hash algorithm used (SHA-256), and the upload timestamp.
3. Saves this information to a 'pdf_documents' table in the PostgreSQL database.

Components added:
- PdfDocument: JPA entity for storing PDF metadata.
- PdfDocumentRepository: Spring Data JPA repository for PdfDocument.
- PdfDocumentService: Service layer for handling business logic (hash generation, data persistence).
- PdfDocumentController: REST controller with a POST endpoint at /api/pdf/upload for file uploads.
- PdfDocumentServiceTest: Unit test for the service layer.

The application.properties file is configured for Hibernate to update the schema, which will create the 'pdf_documents' table.